### PR TITLE
add: tables, models, and error_serializer

### DIFF
--- a/app/controllers/api/v1/users/challenges_controller.rb
+++ b/app/controllers/api/v1/users/challenges_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::Users::ChallengesController < ApplicationController
+
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::UsersController < ApplicationController
+  
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
+
+  def record_not_found
+    render json: ErrorSerializer.new(exception.message).serializable_hash, status: :not_found # 404
+  end
+
+  def record_invalid
+    render json: ErrorSerializer.new(exception.message).serializable_hash, status: :unprocessable_entity #422
+  end
+
+  def imalittleteapot
+    render json: ErrorSerializer.new(exception.message).serializable_hash, status: :teapot #418
+  end
 end

--- a/app/models/grammar_point.rb
+++ b/app/models/grammar_point.rb
@@ -1,0 +1,2 @@
+class GrammarPoint < ApplicationRecord
+end

--- a/app/models/verb.rb
+++ b/app/models/verb.rb
@@ -1,0 +1,2 @@
+class Verb < ApplicationRecord
+end

--- a/app/serializers/challenge_serializer.rb
+++ b/app/serializers/challenge_serializer.rb
@@ -1,0 +1,3 @@
+class ChallengeSerializer
+  include JSONAPI::Serializer
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,20 @@
+class ErrorSerializer
+  include JSONAPI::Serializer
+
+  def initialize(exception, status)
+    @exception = exception
+    @status = status
+  end
+
+  def serializable_hash
+    {
+      error: [
+        {
+          status: @status,
+          title: @exception.class.to_s,
+          detail: @exception.message
+        }
+      ]
+    }
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer
+  include JSONAPI::Serializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,12 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :users, only: [:index, :show] do
+        get '/challenges/prompt', to: 'users/challenges#new'
+        resources :challenges, except: [:update]
+      end
+    end
+  end
 end

--- a/db/migrate/20230513182925_create_grammar_points.rb
+++ b/db/migrate/20230513182925_create_grammar_points.rb
@@ -1,0 +1,11 @@
+class CreateGrammarPoints < ActiveRecord::Migration[7.0]
+  def change
+    create_table :grammar_points do |t|
+      t.string :language
+      t.string :grammar_point
+      t.string :eng_grammar_point
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230513183036_create_verbs.rb
+++ b/db/migrate/20230513183036_create_verbs.rb
@@ -1,0 +1,11 @@
+class CreateVerbs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :verbs do |t|
+      t.string :language
+      t.string :verb
+      t.string :eng_verb
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_230623) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_13_183036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_230623) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_challenges_on_user_id"
+  end
+
+  create_table "grammar_points", force: :cascade do |t|
+    t.string "language"
+    t.string "grammar_point"
+    t.string "eng_grammar_point"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "sentences", force: :cascade do |t|
@@ -40,6 +48,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_230623) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "preferred_lang"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "verbs", force: :cascade do |t|
+    t.string "language"
+    t.string "verb"
+    t.string "eng_verb"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/grammar_point_spec.rb
+++ b/spec/models/grammar_point_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe GrammarPoint, type: :model do
+  describe 'self' do
+    it 'exists' do
+      grammar_point1 = GrammarPoint.create(language: "Spanish", grammar_point: "presente", eng_grammar_point: "simple present tense")
+      
+      expect(grammar_point1).to be_a GrammarPoint
+      expect(grammar_point1.language).to eq("Spanish")
+      expect(grammar_point1.grammar_point).to eq("presente")
+      expect(grammar_point1.eng_grammar_point).to eq("simple present tense")
+    end
+  end
+end

--- a/spec/models/verb_spec.rb
+++ b/spec/models/verb_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Verb, type: :model do
+  describe 'self' do
+    it 'exists' do
+      verb1 = Verb.create(language: "Spanish", verb: "hablar", eng_verb: "to speak")
+
+      expect(verb1).to be_a Verb
+      expect(verb1.language).to eq("Spanish")
+      expect(verb1.verb).to eq("hablar")
+      expect(verb1.eng_verb).to eq("to speak")
+    end
+  end
+end


### PR DESCRIPTION
## Changes: 
- Added grammar point and verb tables, as well as rescue_from methods in application controller
- using an error serializer
- Added routes
- Added models "verb" and "grammar_point" with model testing 

---
This is related to ticket number # 15

This closes ticket number # 15

[] I linted my work.

[] I've updated documentation. (if necessary)

---
(For Fun!) Please include a link to a gif of your feelings about this branch

Link: 