### PR TITLE
BE | `Refactor` to match JSON Contract

### DIFF
--- a/app/controllers/api/v1/users/challenges_controller.rb
+++ b/app/controllers/api/v1/users/challenges_controller.rb
@@ -33,7 +33,6 @@ class Api::V1::Users::ChallengesController < ApplicationController
   def check_challenge
     @challenge = Challenge.find_by(user_id: params[:user_id], id: params[:id])
     return unless @challenge.nil?
-
     cant_delete_challenge
   end
 end

--- a/app/poros/prompt.rb
+++ b/app/poros/prompt.rb
@@ -3,7 +3,7 @@ class Prompt
 
   def initialize(info)
     @id = nil
-    @user_id = info[:user_id]
+    @user_id = info[:user_id].to_i
     @language = info[:language]
     @verb = info[:verb]
     @eng_verb = info[:eng_verb]

--- a/app/poros/prompt.rb
+++ b/app/poros/prompt.rb
@@ -3,7 +3,7 @@ class Prompt
 
   def initialize(info)
     @id = nil
-    @user_id = info[:user_id].to_i
+    @user_id = info[:user_id]
     @language = info[:language]
     @verb = info[:verb]
     @eng_verb = info[:eng_verb]

--- a/app/serializers/challenge_id_serializer.rb
+++ b/app/serializers/challenge_id_serializer.rb
@@ -1,3 +1,4 @@
 class ChallengeIdSerializer
   include JSONAPI::Serializer
+  set_type :challenge
 end

--- a/app/serializers/challenge_serializer.rb
+++ b/app/serializers/challenge_serializer.rb
@@ -1,6 +1,10 @@
 class ChallengeSerializer
   include JSONAPI::Serializer
-  attributes :user_id, :language, :verb, :eng_verb, :image_url, :image_alt_text
+  attributes :language, :verb, :eng_verb, :image_url, :image_alt_text #:user_id,
+
+  attributes :user_id do |object|
+    object.to_s
+  end
 
   attributes :created_at do |object|
     object.created_at.strftime("%m/%e/%Y")
@@ -9,7 +13,7 @@ class ChallengeSerializer
   attributes :sentences do |serializer|
     serializer.sentences.map do |sentence|
       {
-        id: sentence.id,
+        id: sentence.id.to_s,
         grammar_point: sentence.grammar_point,
         eng_grammar_point: sentence.eng_grammar_point,
         user_sent: sentence.user_sent,

--- a/app/serializers/challenge_serializer.rb
+++ b/app/serializers/challenge_serializer.rb
@@ -1,6 +1,6 @@
 class ChallengeSerializer
   include JSONAPI::Serializer
-  attributes :language, :verb, :eng_verb, :image_url, :image_alt_text #:user_id,
+  attributes :language, :verb, :eng_verb, :image_url, :image_alt_text
 
   attributes :user_id do |object|
     object.to_s

--- a/app/serializers/challenge_serializer.rb
+++ b/app/serializers/challenge_serializer.rb
@@ -2,10 +2,6 @@ class ChallengeSerializer
   include JSONAPI::Serializer
   attributes :user_id, :language, :verb, :eng_verb, :image_url, :image_alt_text
 
-  attributes :user_id do |object|
-    object.to_s
-  end
-
   attributes :created_at do |object|
     object.created_at.strftime("%m/%e/%Y")
   end
@@ -13,8 +9,8 @@ class ChallengeSerializer
   attributes :sentences do |serializer|
     serializer.sentences.map do |sentence|
       {
-        id: sentence.id.to_s,
-        grammar_points: sentence.grammar_point,
+        id: sentence.id,
+        grammar_point: sentence.grammar_point,
         eng_grammar_point: sentence.eng_grammar_point,
         user_sent: sentence.user_sent,
         ai_sent: sentence.ai_sent,

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -10,7 +10,7 @@ class ErrorSerializer
     {
       errors: [
         {
-          status: @status,
+          status: @status.to_s,
           title: @exception.class.to_s,
           detail: @exception.message
         }

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -5,7 +5,7 @@ class UserSerializer
   attributes :challenges do |serializer|
     serializer.challenges.map do |challenge|
       {
-        challenge_id: challenge.id,
+        challenge_id: challenge.id.to_s,
         language: challenge.language,
         verb: challenge.verb,
         eng_verb: challenge.eng_verb,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,18 @@
 class UserSerializer
   include JSONAPI::Serializer
-  set_type :user
-  attributes :name, :preferred_lang, :challenges
+  attributes :name, :preferred_lang
+
+  attributes :challenges do |serializer|
+    serializer.challenges.map do |challenge|
+      {
+        challenge_id: challenge.id,
+        language: challenge.language,
+        verb: challenge.verb,
+        eng_verb: challenge.eng_verb,
+        image_url: challenge.image_url,
+        image_alt_text: challenge.image_alt_text,
+        created_at: challenge.created_at.strftime("%m/%e/%Y")
+      }
+    end
+  end
 end

--- a/spec/requests/api/v1/users/challenges_request_spec.rb
+++ b/spec/requests/api/v1/users/challenges_request_spec.rb
@@ -70,15 +70,10 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
         parsed_data = JSON.parse(response.body, symbolize_names: true)
 
         expect(parsed_data).to be_a Hash
+        expect(parsed_data.keys).to eq([:data])
 
-        expect(parsed_data).to have_key(:data)
         expect(parsed_data[:data]).to be_a Hash
-
-        expect(parsed_data[:data]).to have_key(:id)
-        expect(parsed_data[:data][:id]).to be_a String
-
-        expect(parsed_data[:data]).to have_key(:type)
-        expect(parsed_data[:data][:type]).to be_a String
+        expect(parsed_data[:data].keys).to eq([:id, :type])
 
         expect(parsed_data[:data]).to_not have_key(:attributes)
       end
@@ -120,7 +115,7 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
         expect(parsed_data[:errors].first).to be_a Hash
 
         expect(parsed_data[:errors].first).to have_key(:status)
-        expect(parsed_data[:errors].first[:status]).to be_a Integer
+        expect(parsed_data[:errors].first[:status]).to be_a String
 
         expect(parsed_data[:errors].first[:detail]).to be_a String
         expect(parsed_data[:errors].first[:detail]).to eq("Couldn't find User with 'id'=76767676")
@@ -160,13 +155,15 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
         expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
 
         expect(parsed_data[:data][:attributes]).to be_a Hash
-        expect(parsed_data[:data][:attributes].keys).to eq([:user_id, 
-                                                            :language, 
-                                                            :verb, :eng_verb, 
+        expect(parsed_data[:data][:attributes].keys).to eq([:language, 
+                                                            :verb, 
+                                                            :eng_verb, 
                                                             :image_url, 
-                                                            :image_alt_text, 
+                                                            :image_alt_text,
+                                                            :user_id, 
                                                             :created_at, 
-                                                            :sentences])
+                                                            :sentences])                                                 
+        expect(parsed_data[:data][:attributes][:user_id]).to be_a String
 
         expect(parsed_data[:data][:attributes][:sentences]).to be_an Array
         expect(parsed_data[:data][:attributes][:sentences][0]).to be_a Hash
@@ -177,6 +174,7 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
                                                                            :user_sent, 
                                                                            :ai_sent, 
                                                                            :ai_explanation])
+        expect(parsed_data[:data][:attributes][:sentences][0][:id]).to be_a String
       end
     end
 
@@ -195,7 +193,7 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
         expect(parsed_data[:errors].first).to be_a Hash
 
         expect(parsed_data[:errors].first).to have_key(:status)
-        expect(parsed_data[:errors].first[:status]).to be_a Integer
+        expect(parsed_data[:errors].first[:status]).to be_a String
 
         expect(parsed_data[:errors].first[:detail]).to be_a String
         expect(parsed_data[:errors].first[:detail]).to eq("Couldn't find Challenge with 'id'=23452345456")

--- a/spec/requests/api/v1/users/challenges_request_spec.rb
+++ b/spec/requests/api/v1/users/challenges_request_spec.rb
@@ -4,40 +4,14 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
   describe "#new" do
     before(:each) do
       @turkish_user = User.create(id: 55, name: "Deniz", preferred_lang: "Turkish")
-      @spanish_user = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
-
-      @tr_challenge1 = Challenge.create(id: 50, user_id: 55, language: "Turkish", verb: "(e/a) gitmek", eng_verb: "to go",
-                                        image_url: "https://images.unsplash.com/photo-1500835556837-99ac94a94552?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80", image_alt_text: "Plane flying")
-      @tr_sentence1 = Sentence.create(id: 10, challenge_id: 50, grammar_point: "gelecek zaman (-ecek)", eng_grammar_point: "future tense",
-                                      user_sent: "Yarın annem beni havalimanına bırakmak için araba kullanacak.", ai_sent: "Yarın annem beni havalimanına bırakmak için araba kullanacak.")
-      @tr_sentence2 = Sentence.create(id: 11, challenge_id: 50, grammar_point: "olumsuz geçmiş zaman (-me/-ma + di/-tı)", eng_grammar_point: "negative past tense",
-                                      user_sent: "Dün havalimana gittik ama arkadaşım uçak gelmedi.", ai_sent: "Dün havalimanına gittik, ancak arkadaşımızın uçağı gelmedi.")
-
-      @tr_challenge2 = Challenge.create(id: 51, user_id: 55, language: "Turkish", verb: "(i) bilmek", eng_verb: "to know",
-                                        image_url: "https://images.unsplash.com/photo-1525616332682-f763cf05c55e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80", image_alt_text: "Ganesha")
-      @tr_sentence3 = Sentence.create(id: 12, challenge_id: 51, grammar_point: "belirsiz geçmiş zaman (-miş)", eng_grammar_point: "evidential past tense",
-                                      user_sent: "Hindistan'ı ziyaret ettiği için, bir fili binmeyi bilmiş.", ai_sent: "Hindistan'ı ziyaret ettiği için, bir fili binmeyi bilmiş.")
-      @tr_sentence4 = Sentence.create(id: 13, challenge_id: 51, grammar_point: "zarf fiili (erek/arak)", eng_grammar_point: "adverbial participle",
-                                      user_sent: "Filleri çok şey bilerek, hayvanat bahçesin işini alabildim.", ai_sent: "Filler hakkında çok şey bilerek, hayvanat bahçesinde işi alabildim.")
-
-      @sp_challenge1 = Challenge.create(id: 100, user_id: 1, language: "Spanish", verb: "hablar", eng_verb: "to speak",
-                                        image_url: "https://images.unsplash.com/photo-1503917988258-f87a78e3c995?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1887&q=80", image_alt_text: "Paris from above")
-      @sp_sentence1 = Sentence.create(id: 40, challenge_id: 100, grammar_point: "presente", eng_grammar_point: "simple present tense", user_sent: "Él habla español y francés con fluidez.",
-                                      ai_sent: "Él habla español y francés con fluidez.")
-      @sp_sentence2 = Sentence.create(id: 41, challenge_id: 100, grammar_point: "pretérito indefinido", eng_grammar_point: "simple past tense",
-                                      user_sent: "Mi dos hijos estaban hablo francés al revisor de tren.", ai_sent: "Mis dos hijos estaban hablando francés al revisor del tren.")
 
       @turk_verb1 = Verb.create(language: "Turkish", verb: "(le/la) uğraşmak", eng_verb: "to deal with")
       @turk_verb2 = Verb.create(language: "Turkish", verb: "(e/a) gitmek", eng_verb: "to go")
       @turk_verb3 = Verb.create(language: "Turkish", verb: "(e/a) tavsiye etmek", eng_verb: "to recommend")
+
       @turk_gram1 = GrammarPoint.create(language: "Turkish", grammar_point: "şimdiki zaman (-iyor)", eng_grammar_point: "present/present continuous tense")
       @turk_gram2 = GrammarPoint.create(language: "Turkish", grammar_point: "şimdiki zaman resmi (-mekte)", eng_grammar_point: "formal present/present continuous tense")
       @turk_gram3 = GrammarPoint.create(language: "Turkish", grammar_point: "geniş zaman (-ir/-er)", eng_grammar_point: "simple present tense")
-
-      @spanish_verb1 = Verb.create(language: "Spanish", verb: "hablar", eng_verb: "to speak")
-      @spanish_verb2 = Verb.create(language: "Spanish", verb: "bailar", eng_verb: "to dance")
-      @span_gram1 = GrammarPoint.create(language: "Spanish", grammar_point: "presente", eng_grammar_point: "simple present tense")
-      @span_gram2 = GrammarPoint.create(language: "Spanish", grammar_point: "pretérito perfecto", eng_grammar_point: "present perfect tense")
     end
 
     describe "when succesful" do
@@ -60,6 +34,7 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
 
       @turk_verb1 = Verb.create(language: "Turkish", verb: "(le/la) uğraşmak", eng_verb: "to deal with")
       @turk_verb2 = Verb.create(language: "Turkish", verb: "(e/a) gitmek", eng_verb: "to go")
+      @turk_verb3 = Verb.create(language: "Turkish", verb: "(e/a) tavsiye etmek", eng_verb: "to recommend")
 
       @turk_gram1 = GrammarPoint.create(language: "Turkish", grammar_point: "şimdiki zaman (-iyor)", eng_grammar_point: "present/present continuous tense")
       @turk_gram2 = GrammarPoint.create(language: "Turkish", grammar_point: "şimdiki zaman resmi (-mekte)", eng_grammar_point: "formal present/present continuous tense")
@@ -155,23 +130,19 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
 
   describe "#show" do
     before(:each) do
-      @user1 = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
-      @user2 = User.create(id: 55, name: "Deniz", preferred_lang: "Turkish")
-      @user3 = User.create(id: 100, name: "Megan", preferred_lang: "English")
-
       @verb1 = Verb.create(language: "Spanish", verb: "hablar", eng_verb: "to speak")
       @verb2 = Verb.create(language: "Spanish", verb: "bailar", eng_verb: "to dance")
-
+      
       @point1 = GrammarPoint.create(language: "Spanish", grammar_point: "presente", eng_grammar_point: "simple present tense")
       @point2 = GrammarPoint.create(language: "Spanish", grammar_point: "pretérito perfecto", eng_grammar_point: "present perfect tense")
-
-      @challenge1 = @user1.challenges.create(id: 101, user_id: 1, language: "Spanish", verb: @verb1.verb, eng_verb: @verb1.eng_verb, image_url: "image", image_alt_text: "alt_text")
-      @challenge2 = @user2.challenges.create(id: 102, user_id: 55, language: "Spanish", verb: @verb2.verb, eng_verb: @verb2.eng_verb, image_url: "image", image_alt_text: "alt_text")
-
-      @sentence1 = @challenge1.sentences.create(id: 42, challenge_id: 101, grammar_point: @point1.grammar_point, eng_grammar_point: @point1.eng_grammar_point,
-                                                user_sent: "Me gusta comer sushi de vez en cuando.", ai_sent: "Me gusta comer sushi de vez en cuando.")
-      @sentence2 = @challenge2.sentences.create(id: 43, challenge_id: 101, grammar_point: @point2.grammar_point, eng_grammar_point: @point2.eng_grammar_point,
-                                                user_sent: "Mis hijos no comer platos de fideos.", ai_sent: "Mis hijos no comerán platos de fideos.")
+      
+      @user1 = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
+      
+      @challenge1 = Challenge.create(id: 101, user_id: 1, language: "Spanish", verb: @verb1.verb, eng_verb: @verb1.eng_verb, image_url: "image", image_alt_text: "alt_text")
+      @sentence1 = Sentence.create(id: 42, challenge_id: 101, grammar_point: "presente", eng_grammar_point: "simple present tense", user_sent: "Me gusta comer sushi de vez en cuando.",
+        ai_sent: "Me gusta comer sushi de vez en cuando.", ai_explanation: "Correct! You win!")
+      @sentence2 = Sentence.create(id: 43, challenge_id: 101, grammar_point: "futuro", eng_grammar_point: "simple future tense", user_sent: "Mis hijos no comer platos de fideos.",
+        ai_sent: "Mis hijos no comerán platos de fideos.", ai_explanation: "Here, I added 'án' to 'comer' to correctly conjugate the verb into the future tense.")
     end
 
     describe "when successful" do
@@ -183,46 +154,29 @@ RSpec.describe "Api::V1::Users::Challenges", :vcr, type: :request do
         parsed_data = JSON.parse(response.body, symbolize_names: true)
 
         expect(parsed_data).to be_a Hash
+        expect(parsed_data.keys).to eq([:data])
 
-        expect(parsed_data).to have_key(:data)
         expect(parsed_data[:data]).to be_a Hash
+        expect(parsed_data[:data].keys).to eq([:id, :type, :attributes])
 
-        expect(parsed_data[:data]).to have_key(:id)
-        expect(parsed_data[:data][:id]).to be_a String
-
-        expect(parsed_data[:data]).to have_key(:type)
-        expect(parsed_data[:data][:type]).to be_a String
-
-        expect(parsed_data[:data]).to have_key(:attributes)
         expect(parsed_data[:data][:attributes]).to be_a Hash
+        expect(parsed_data[:data][:attributes].keys).to eq([:user_id, 
+                                                            :language, 
+                                                            :verb, :eng_verb, 
+                                                            :image_url, 
+                                                            :image_alt_text, 
+                                                            :created_at, 
+                                                            :sentences])
 
-        expect(parsed_data[:data][:attributes]).to have_key(:user_id)
-        expect(parsed_data[:data][:attributes][:user_id]).to be_a String
+        expect(parsed_data[:data][:attributes][:sentences]).to be_an Array
+        expect(parsed_data[:data][:attributes][:sentences][0]).to be_a Hash
 
-        expect(parsed_data[:data][:attributes]).to have_key(:language)
-        expect(parsed_data[:data][:attributes][:language]).to be_a String
-
-        expect(parsed_data[:data][:attributes]).to have_key(:verb)
-        expect(parsed_data[:data][:attributes][:verb]).to be_a String
-
-        expect(parsed_data[:data][:attributes]).to have_key(:eng_verb)
-        expect(parsed_data[:data][:attributes][:eng_verb]).to be_a String
-
-        expect(parsed_data[:data][:attributes]).to have_key(:image_url)
-        expect(parsed_data[:data][:attributes][:image_url]).to be_a String
-
-        expect(parsed_data[:data][:attributes]).to have_key(:image_alt_text)
-        expect(parsed_data[:data][:attributes][:image_alt_text]).to be_a String
-      end
-
-      it 'returns any challenge by id' do
-        get "/api/v1/users/#{@user2.id}/challenges/#{@challenge2.id}"
-
-        expect(response).to be_successful
-
-        parsed_data = JSON.parse(response.body, symbolize_names: true)
-
-        expect(parsed_data).to be_a Hash
+        expect(parsed_data[:data][:attributes][:sentences][0].keys).to eq([:id,
+                                                                           :grammar_point, 
+                                                                           :eng_grammar_point,
+                                                                           :user_sent, 
+                                                                           :ai_sent, 
+                                                                           :ai_explanation])
       end
     end
 

--- a/spec/requests/api/v1/users_requests_spec.rb
+++ b/spec/requests/api/v1/users_requests_spec.rb
@@ -1,117 +1,134 @@
 require "rails_helper"
 
 RSpec.describe "Users API", type: :request do
-  before :each do
-    @user1 = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
-    @user2 = User.create(id: 55, name: "Deniz", preferred_lang: "Turkish")
-    @user3 = User.create(id: 100, name: "Megan", preferred_lang: "English")
-    @user4 = User.create(id: 453, name: "Jim", preferred_lang: "Portugeuse")
-    @Challenge_1 = Challenge.create(id: 100, user_id: 1, language: "Spanish", verb: "hablar", eng_verb: "to speak",
-                                    image_url: "https://images.unsplash.com/photo-1503917988258-f87a78e3c995?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1887&q=80", image_alt_text: "Paris from above")
-    @Challenge_2 = Challenge.create(id: 101, user_id: 1, language: "Spanish", verb: "comer", eng_verb: "to eat",
-                                    image_url: "https://images.unsplash.com/photo-1602273660127-a0000560a4c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=736&q=80", image_alt_text: "Noodles, Chicken, and Momos")
-    @Challenge_3 = Challenge.create(id: 102, user_id: 1, language: "Spanish", verb: "necesitar", eng_verb: "to need",
-                                    image_url: "https://images.unsplash.com/photo-1682253572700-4173885b68f2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80", image_alt_text: "playing guitar")
-  end
-  it "returns all users" do
-    get "/api/v1/users"
+  describe "#index" do
+    before :each do
+      @user1 = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
+      @user2 = User.create(id: 55, name: "Deniz", preferred_lang: "Turkish")
+      @user3 = User.create(id: 100, name: "Megan", preferred_lang: "English")
+      @user4 = User.create(id: 453, name: "Jim", preferred_lang: "Portugeuse")
+      @challenge_1 = Challenge.create(id: 100, user_id: 1, language: "Spanish", verb: "hablar", eng_verb: "to speak",
+                                      image_url: "https://images.unsplash.com/photo-1503917988258-f87a78e3c995?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1887&q=80", image_alt_text: "Paris from above")
+      @challenge_2 = Challenge.create(id: 101, user_id: 1, language: "Spanish", verb: "comer", eng_verb: "to eat",
+                                      image_url: "https://images.unsplash.com/photo-1602273660127-a0000560a4c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=736&q=80", image_alt_text: "Noodles, Chicken, and Momos")
+      @challenge_3 = Challenge.create(id: 102, user_id: 1, language: "Spanish", verb: "necesitar", eng_verb: "to need",
+                                      image_url: "https://images.unsplash.com/photo-1682253572700-4173885b68f2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80", image_alt_text: "playing guitar")
+    end
 
-    expect(response).to be_successful
+    context "when successful" do
+      it "returns all users" do
+        get "/api/v1/users"
 
-    parsed_data = JSON.parse(response.body, symbolize_names: true)
+        expect(response).to be_successful
 
-    expect(parsed_data).to be_a(Hash)
-    expect(parsed_data).to have_key(:data)
-    expect(parsed_data[:data]).to be_an(Array)
-    parsed_data[:data].each do |user|
-      expect(user).to have_key(:id)
-      expect(user[:id]).to be_an(String)
-      expect(user).to have_key(:type)
-      expect(user[:type]).to be_an(String)
-      expect(user[:type]).to eq("user")
-      expect(user).to have_key(:attributes)
-      expect(user[:attributes]).to be_an(Hash)
-      expect(user[:attributes].keys).to eq([:name, :preferred_lang, :challenges])
-      expect(user[:attributes][:name]).to be_a(String)
-      expect(user[:attributes][:preferred_lang]).to be_a(String)
-      expect(user[:attributes][:challenges]).to be_an(Array)
+        parsed_data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(parsed_data).to be_a(Hash)
+        expect(parsed_data).to have_key(:data)
+        expect(parsed_data[:data]).to be_an(Array)
+        parsed_data[:data].each do |user|
+          expect(user).to have_key(:id)
+          expect(user[:id]).to be_an(String)
+          expect(user).to have_key(:type)
+          expect(user[:type]).to be_an(String)
+          expect(user[:type]).to eq("user")
+          expect(user).to have_key(:attributes)
+          expect(user[:attributes]).to be_an(Hash)
+          expect(user[:attributes].keys).to eq([:name, :preferred_lang, :challenges])
+          expect(user[:attributes][:name]).to be_a(String)
+          expect(user[:attributes][:preferred_lang]).to be_a(String)
+          expect(user[:attributes][:challenges]).to be_an(Array)
+        end
+      end
     end
   end
-  context " When successful" do
-    it "returns a single user" do
-      get "/api/v1/users/1"
 
-      expect(response).to be_successful
-
-      parsed_data = JSON.parse(response.body, symbolize_names: true)
-
-      expect(parsed_data).to be_a(Hash)
-      expect(parsed_data).to have_key(:data)
-      expect(parsed_data[:data]).to be_a(Hash)
-      expect(parsed_data[:data].keys).to eq([:id,
-                                             :type,
-                                             :attributes])
-      expect(parsed_data[:data][:id]).to eq(@user1.id.to_s)
-      expect(parsed_data[:data][:id]).to be_a(String)
-      expect(parsed_data[:data][:type]).to be_a(String)
-      expect(parsed_data[:data][:attributes]).to be_a(Hash)
-      expect(parsed_data[:data][:attributes].keys).to eq([:name,
-                                                          :preferred_lang,
-                                                          :challenges])
-      expect(parsed_data[:data][:attributes][:name]).to eq(@user1.name)
-      expect(parsed_data[:data][:attributes][:name]).to be_a(String)
-      expect(parsed_data[:data][:attributes][:preferred_lang]).to eq(@user1.preferred_lang)
-      expect(parsed_data[:data][:attributes][:preferred_lang]).to be_a(String)
-      expect(parsed_data[:data][:attributes][:challenges]).to be_an(Array)
-      expect(parsed_data[:data][:attributes][:challenges].length).to eq(3)
-
-      challenge = parsed_data[:data][:attributes][:challenges][0]
-      expect(challenge).to be_a(Hash)
-      expect(challenge.keys).to eq([:id,
-                                    :user_id,
-                                    :language,
-                                    :verb,
-                                    :eng_verb,
-                                    :image_url,
-                                    :image_alt_text,
-                                    :created_at,
-                                    :updated_at])
-      expect(challenge[:id]).to be_an(Integer)
-      expect(challenge[:user_id]).to eq(@Challenge_1.user_id)
-      expect(challenge[:user_id]).to be_an(Integer)
-      expect(challenge[:language]).to eq(@Challenge_1.language)
-      expect(challenge[:language]).to be_a(String)
-      expect(challenge[:verb]).to eq(@Challenge_1.verb)
-      expect(challenge[:verb]).to be_a(String)
-      expect(challenge[:eng_verb]).to eq(@Challenge_1.eng_verb)
-      expect(challenge[:eng_verb]).to be_a(String)
-      expect(challenge[:image_url]).to eq(@Challenge_1.image_url)
-      expect(challenge[:image_url]).to be_a(String)
-      expect(challenge[:image_alt_text]).to eq(@Challenge_1.image_alt_text)
-      expect(challenge[:image_alt_text]).to be_a(String)
-      expect(challenge[:created_at]).to be_a(String)
-      expect(challenge[:updated_at]).to be_a(String)
+  describe "#show" do
+    before :each do
+      @user1 = User.create(id: 1, name: "Alexis", preferred_lang: "Spanish")
+      @user2 = User.create(id: 55, name: "Deniz", preferred_lang: "Turkish")
+      @user3 = User.create(id: 100, name: "Megan", preferred_lang: "English")
+      @user4 = User.create(id: 453, name: "Jim", preferred_lang: "Portugeuse")
+      @challenge_1 = Challenge.create(id: 100, user_id: 1, language: "Spanish", verb: "hablar", eng_verb: "to speak",
+                                      image_url: "https://images.unsplash.com/photo-1503917988258-f87a78e3c995?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1887&q=80", image_alt_text: "Paris from above")
+      @challenge_2 = Challenge.create(id: 101, user_id: 1, language: "Spanish", verb: "comer", eng_verb: "to eat",
+                                      image_url: "https://images.unsplash.com/photo-1602273660127-a0000560a4c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=736&q=80", image_alt_text: "Noodles, Chicken, and Momos")
+      @challenge_3 = Challenge.create(id: 102, user_id: 1, language: "Spanish", verb: "necesitar", eng_verb: "to need",
+                                      image_url: "https://images.unsplash.com/photo-1682253572700-4173885b68f2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80", image_alt_text: "playing guitar")
     end
-  end
-  context " When unsuccessful" do
-    it "returns a 404 status with an error response if user is not found" do
-      get "/api/v1/users/1000"
-      expect(response).to_not be_successful
-      expect(response.status).to eq(404)
 
-      parsed_error_data = JSON.parse(response.body, symbolize_names: true)
-      expect(parsed_error_data).to be_a(Hash)
-      expect(parsed_error_data).to have_key(:errors)
-      expect(parsed_error_data[:errors]).to be_a(Array)
-      expect(parsed_error_data[:errors][0].keys).to eq([:status,
-                                                        :title,
-                                                        :detail])
-      expect(parsed_error_data[:errors][0][:status]).to be_a(Integer)
-      expect(parsed_error_data[:errors][0][:status]).to eq(404)
-      expect(parsed_error_data[:errors][0][:title]).to be_a(String)
-      expect(parsed_error_data[:errors][0][:title]).to eq("ActiveRecord::RecordNotFound")
-      expect(parsed_error_data[:errors][0][:detail]).to be_a(String)
-      expect(parsed_error_data[:errors][0][:detail]).to eq("Couldn't find User with 'id'=1000")
+    context "when successful" do
+      it "returns a single user" do
+        get "/api/v1/users/1"
+
+        expect(response).to be_successful
+
+        parsed_data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(parsed_data).to be_a(Hash)
+        expect(parsed_data).to have_key(:data)
+        expect(parsed_data[:data]).to be_a(Hash)
+        expect(parsed_data[:data].keys).to eq([:id,
+                                              :type,
+                                              :attributes])
+        expect(parsed_data[:data][:id]).to eq(@user1.id.to_s)
+        expect(parsed_data[:data][:id]).to be_a(String)
+        expect(parsed_data[:data][:type]).to be_a(String)
+        expect(parsed_data[:data][:attributes]).to be_a(Hash)
+        expect(parsed_data[:data][:attributes].keys).to eq([:name,
+                                                            :preferred_lang,
+                                                            :challenges])
+        expect(parsed_data[:data][:attributes][:name]).to eq(@user1.name)
+        expect(parsed_data[:data][:attributes][:name]).to be_a(String)
+        expect(parsed_data[:data][:attributes][:preferred_lang]).to eq(@user1.preferred_lang)
+        expect(parsed_data[:data][:attributes][:preferred_lang]).to be_a(String)
+        expect(parsed_data[:data][:attributes][:challenges]).to be_an(Array)
+        expect(parsed_data[:data][:attributes][:challenges].length).to eq(3)
+
+        challenge = parsed_data[:data][:attributes][:challenges][0]
+        expect(challenge).to be_a(Hash)
+        expect(challenge.keys).to eq([:challenge_id,
+                                      :language,
+                                      :verb,
+                                      :eng_verb,
+                                      :image_url,
+                                      :image_alt_text,
+                                      :created_at])
+        expect(challenge[:challenge_id]).to be_an(Integer)
+        expect(challenge[:language]).to eq(@challenge_1.language)
+        expect(challenge[:language]).to be_a(String)
+        expect(challenge[:verb]).to eq(@challenge_1.verb)
+        expect(challenge[:verb]).to be_a(String)
+        expect(challenge[:eng_verb]).to eq(@challenge_1.eng_verb)
+        expect(challenge[:eng_verb]).to be_a(String)
+        expect(challenge[:image_url]).to eq(@challenge_1.image_url)
+        expect(challenge[:image_url]).to be_a(String)
+        expect(challenge[:image_alt_text]).to eq(@challenge_1.image_alt_text)
+        expect(challenge[:image_alt_text]).to be_a(String)
+        expect(challenge[:created_at]).to be_a(String)
+      end
+    end
+
+    context "when NOT successful" do
+      it "returns a 404 status with an error response if user is not found" do
+        get "/api/v1/users/1000"
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+
+        parsed_error_data = JSON.parse(response.body, symbolize_names: true)
+        expect(parsed_error_data).to be_a(Hash)
+        expect(parsed_error_data).to have_key(:errors)
+        expect(parsed_error_data[:errors]).to be_a(Array)
+        expect(parsed_error_data[:errors][0].keys).to eq([:status,
+                                                          :title,
+                                                          :detail])
+        expect(parsed_error_data[:errors][0][:status]).to be_a(Integer)
+        expect(parsed_error_data[:errors][0][:status]).to eq(404)
+        expect(parsed_error_data[:errors][0][:title]).to be_a(String)
+        expect(parsed_error_data[:errors][0][:title]).to eq("ActiveRecord::RecordNotFound")
+        expect(parsed_error_data[:errors][0][:detail]).to be_a(String)
+        expect(parsed_error_data[:errors][0][:detail]).to eq("Couldn't find User with 'id'=1000")
+      end
     end
   end
 end

--- a/spec/requests/api/v1/users_requests_spec.rb
+++ b/spec/requests/api/v1/users_requests_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Users API", type: :request do
                                       :image_url,
                                       :image_alt_text,
                                       :created_at])
-        expect(challenge[:challenge_id]).to be_an(Integer)
+        expect(challenge[:challenge_id]).to be_an(String)
         expect(challenge[:language]).to eq(@challenge_1.language)
         expect(challenge[:language]).to be_a(String)
         expect(challenge[:verb]).to eq(@challenge_1.verb)
@@ -122,8 +122,8 @@ RSpec.describe "Users API", type: :request do
         expect(parsed_error_data[:errors][0].keys).to eq([:status,
                                                           :title,
                                                           :detail])
-        expect(parsed_error_data[:errors][0][:status]).to be_a(Integer)
-        expect(parsed_error_data[:errors][0][:status]).to eq(404)
+        expect(parsed_error_data[:errors][0][:status]).to be_a(String)
+        expect(parsed_error_data[:errors][0][:status]).to eq("404")
         expect(parsed_error_data[:errors][0][:title]).to be_a(String)
         expect(parsed_error_data[:errors][0][:title]).to eq("ActiveRecord::RecordNotFound")
         expect(parsed_error_data[:errors][0][:detail]).to be_a(String)


### PR DESCRIPTION
## Changes: 
- fixed `ChallengeSerializer` to return data correctly (removed extra :user_id)
- updated `UserSerializer` to return only what FE wants 
- reorganized `user_facade_spec.rb` tests to clearly show which action is being tested
- updated tests in `user_facade_spec.rb` to match changes made 
- updated `ErrorSerializer` to return status as a string (as per the JSON contract)

NOTE: We definitely need a secondary refactor to ensure all TEST DATA and TESTS reflected the updates sentences: they now have the attribute `ai_explanation`.

---
This is related to #44

This closes #44

[] I linted my work.

[X] I've updated documentation. (if necessary)

---
(For Fun!) Please include a link to a gif of your feelings about this branch

Link:  Changing everything to strings be like: https://i.imgflip.com/278xmg.jpg?a467664